### PR TITLE
Remove 'mobile service tools'.

### DIFF
--- a/recommendations/Deployment.md
+++ b/recommendations/Deployment.md
@@ -18,7 +18,6 @@
       - test independently in production
       - quickly roll over to a different stack, enabling [Blue Green Deploys](http://martinfowler.com/bliki/BlueGreenDeployment.html)
 
-  - [Mobile Service Tools](https://github.com/gilt/mobile-service-tools) (Closed Source)
   - [sbt-codedeploy](https://github.com/gilt/sbt-codedeploy)
 
 ## Hold


### PR DESCRIPTION
It's really just a glue between mobile account & CodeDeploy.
Fundamentally we are using CodeDeploy, so, it's confusing
to have it here as an independent choice.