### PR TITLE
Node.js --> Adopt

### DIFF
--- a/recommendations/frameworks/JavaScript.md
+++ b/recommendations/frameworks/JavaScript.md
@@ -1,5 +1,5 @@
 # Web
 
-##Trial
+##Adopt
 
   - [Node.js](https://nodejs.org/)


### PR DESCRIPTION
I noticed at the Arch council yesterday that Node.js was still in 'Trial' I believe it's overdue that it moves to the 'Adopt' group.