### PR TITLE
Add AWS Batch to Trial

### DIFF
--- a/recommendations/Jobs.md
+++ b/recommendations/Jobs.md
@@ -7,7 +7,10 @@
 ## Trial
 
   - [Sundial](https://github.com/gilt/sundial)
-    Scheduled workflow engine leveraging ECS to run arbitrary commands in docker containers.
+    Scheduled workflow engine leveraging ECS and/or AWS Batch to run jobs in docker containers with dependency graph management.
+
+  - [AWS Batch](https://aws.amazon.com/batch/)
+    AWS Service for managing running Docker jobs on ECS
 
 ## Assess
 


### PR DESCRIPTION
A few teams using this now.

Also Sundial is using it as its backend in place of native ECS